### PR TITLE
Support full block overlays

### DIFF
--- a/src/main/java/dev/microcontrollers/simpleblockoverlay/SimpleBlockOverlay.java
+++ b/src/main/java/dev/microcontrollers/simpleblockoverlay/SimpleBlockOverlay.java
@@ -1,11 +1,73 @@
 package dev.microcontrollers.simpleblockoverlay;
 
+import com.mojang.blaze3d.systems.RenderSystem;
 import dev.microcontrollers.simpleblockoverlay.config.SimpleBlockOverlayConfig;
+import dev.microcontrollers.simpleblockoverlay.util.ColorUtil;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.*;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.BlockPos;
+
+import java.awt.*;
 
 public class SimpleBlockOverlay implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		SimpleBlockOverlayConfig.CONFIG.load();
+
+		WorldRenderEvents.LAST.register(SimpleBlockOverlay::renderOutlineBox);
+	}
+
+	public static void renderOutlineBox(WorldRenderContext context) {
+		HitResult hitResult = MinecraftClient.getInstance().crosshairTarget;
+		if (!(context.blockOutlines()  && hitResult != null && hitResult.getType() == HitResult.Type.BLOCK)) {
+			return;
+		}
+		ClientWorld world = context.world();
+		BlockPos pos = ((BlockHitResult) hitResult).getBlockPos();
+		BlockState state = world.getBlockState(pos);
+
+		Tessellator tessellator = Tessellator.getInstance();
+		BufferBuilder buffer = tessellator.getBuffer();
+
+		buffer.begin(VertexFormat.DrawMode.TRIANGLE_STRIP, VertexFormats.POSITION_COLOR);
+
+		Color color = ColorUtil.getColor();
+
+		float cameraX = (float) context.camera().getPos().getX();
+		float cameraY = (float) context.camera().getPos().getY();
+		float cameraZ = (float) context.camera().getPos().getZ();
+
+		state.getSidesShape(world, pos).forEachBox((minX, minY, minZ, maxX, maxY, maxZ) -> {
+			// We make the cube a tiny bit lager to avoid z fighting
+			double zFightingOffset = 0.001;
+			WorldRenderer.renderFilledBox(context.matrixStack(),
+					buffer,
+					(float) (pos.getX() + minX - cameraX - zFightingOffset),
+					(float) (pos.getY() + minY - cameraY - zFightingOffset),
+					(float) (pos.getZ() + minZ - cameraZ - zFightingOffset),
+					(float) (pos.getX() + maxX - cameraX + zFightingOffset),
+					(float) (pos.getY() + maxY - cameraY + zFightingOffset),
+					(float) (pos.getZ() + maxZ - cameraZ + zFightingOffset),
+					color.getRed() / 255F,
+					color.getGreen() / 255F,
+					color.getBlue() / 255F,
+					color.getAlpha() / 255F);
+		});
+
+		RenderSystem.enableBlend();
+		RenderSystem.enableDepthTest();
+		RenderSystem.setShader(GameRenderer::getPositionColorProgram);
+
+		tessellator.draw();
+
+		RenderSystem.disableBlend();
+		RenderSystem.disableDepthTest();
 	}
 }

--- a/src/main/java/dev/microcontrollers/simpleblockoverlay/util/ColorUtil.java
+++ b/src/main/java/dev/microcontrollers/simpleblockoverlay/util/ColorUtil.java
@@ -19,24 +19,21 @@ public class ColorUtil {
         return Color.getHSBColor((float) (rainbowState / 360.0F), SimpleBlockOverlayConfig.CONFIG.instance().saturation, SimpleBlockOverlayConfig.CONFIG.instance().brightness);
     }
 
-    public static void setLineColor(Args args, int offset) {
-        float red, green, blue, alpha;
+    public static Color getColor() {
         if (SimpleBlockOverlayConfig.CONFIG.instance().chroma) {
             Color color = ColorUtil.rainbow();
-            red = color.getRed();
-            green = color.getGreen();
-            blue = color.getBlue();
-            alpha = SimpleBlockOverlayConfig.CONFIG.instance().alpha;
+            return new Color( color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F, SimpleBlockOverlayConfig.CONFIG.instance().alpha / 255F);
         } else {
-            red = SimpleBlockOverlayConfig.CONFIG.instance().solidColor.getRed();
-            green = SimpleBlockOverlayConfig.CONFIG.instance().solidColor.getGreen();
-            blue = SimpleBlockOverlayConfig.CONFIG.instance().solidColor.getBlue();
-            alpha = SimpleBlockOverlayConfig.CONFIG.instance().solidColor.getAlpha();
+            return SimpleBlockOverlayConfig.CONFIG.instance().solidColor;
         }
-        args.set(6 - offset, red / 255F);
-        args.set(7 - offset, green / 255F);
-        args.set(8 - offset, blue / 255F);
-        args.set(9 - offset, alpha / 255F);
+    }
+
+    public static void setLineColor(Args args, int offset) {
+        Color color = getColor();
+        args.set(6 - offset, color.getRed() / 255F);
+        args.set(7 - offset,  color.getGreen() / 255F);
+        args.set(8 - offset, color.getBlue() / 255F);
+        args.set(9 - offset, color.getAlpha() / 255F);
     }
 }
 


### PR DESCRIPTION
So yeah, finally we have full block outlines.
Wohoo!

![image](https://github.com/MicrocontrollersDev/Simple-Block-Overlay/assets/67533827/76479285-23b6-46ca-a6ed-c3a31cd41290)
![image](https://github.com/MicrocontrollersDev/Simple-Block-Overlay/assets/67533827/2a4d7a11-1ffc-44df-a9f8-10062048fe83)
It even works with most of the unusual shapes.

![image](https://github.com/MicrocontrollersDev/Simple-Block-Overlay/assets/67533827/75197638-20ee-474e-8697-b3216839023f)

Closes #1

Notes
- I'm not sure if you want the rendering code to sit in the mod initializer class.
- I think it would be good to support the filled box having a separate color from the outline (e.g the outline is red and the fill is blue) but I'm too lazy to implement this myself, sorry 😅
