### PR TITLE
Add option to force the outline rendering

### DIFF
--- a/src/main/java/dev/microcontrollers/simpleblockoverlay/config/SimpleBlockOverlayConfig.java
+++ b/src/main/java/dev/microcontrollers/simpleblockoverlay/config/SimpleBlockOverlayConfig.java
@@ -1,6 +1,7 @@
 package dev.microcontrollers.simpleblockoverlay.config;
 
 import dev.isxander.yacl3.api.*;
+import dev.isxander.yacl3.api.controller.BooleanControllerBuilder;
 import dev.isxander.yacl3.api.controller.FloatSliderControllerBuilder;
 import dev.isxander.yacl3.api.controller.TickBoxControllerBuilder;
 import dev.isxander.yacl3.config.v2.api.ConfigClassHandler;
@@ -26,6 +27,7 @@ public class SimpleBlockOverlayConfig {
     @SerialEntry public float saturation = 1F;
     @SerialEntry public float brightness = 1F;
     @SerialEntry public float speed = 0.25F;
+    @SerialEntry public boolean alwaysRenderOutline = false;
 
     @SuppressWarnings("deprecation")
     public static Screen configScreen(Screen parent) {
@@ -92,6 +94,18 @@ public class SimpleBlockOverlayConfig {
                                             .range(0F, 1F)
                                             .step(0.1F))
                                     .build())
+                                .build())
+
+                        // Misc
+
+                        .group(OptionGroup.createBuilder()
+                                .name(Text.literal("Misc"))
+                                .option(Option.createBuilder(boolean.class)
+                                        .name(Text.literal("Always render block overlay"))
+                                        .description(OptionDescription.of(Text.literal("Always renders the outline, ignoring some checks")))
+                                        .binding(false, () -> config.alwaysRenderOutline, newVal -> config.alwaysRenderOutline = newVal)
+                                        .controller(BooleanControllerBuilder::create)
+                                        .build())
                                 .build())
                         .build()
         ))).generateScreen(parent);

--- a/src/main/java/dev/microcontrollers/simpleblockoverlay/mixin/GameRendererMixin.java
+++ b/src/main/java/dev/microcontrollers/simpleblockoverlay/mixin/GameRendererMixin.java
@@ -1,0 +1,18 @@
+package dev.microcontrollers.simpleblockoverlay.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import dev.microcontrollers.simpleblockoverlay.config.SimpleBlockOverlayConfig;
+import net.minecraft.client.render.GameRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(GameRenderer.class)
+public class GameRendererMixin {
+    @ModifyReturnValue(
+            method = "shouldRenderBlockOutline",
+            at = @At("RETURN")
+    )
+    private boolean overrideRenderingCondition(boolean original) {
+        return SimpleBlockOverlayConfig.CONFIG.instance().alwaysRenderOutline || original;
+    }
+}

--- a/src/main/resources/simpleblockoverlay.mixins.json
+++ b/src/main/resources/simpleblockoverlay.mixins.json
@@ -4,6 +4,7 @@
   "plugin": "dev.microcontrollers.simpleblockoverlay.SimpleBlockOverlayMixinPlugin",
   "compatibilityLevel": "JAVA_17",
   "client": [
+    "GameRendererMixin",
     "WorldRendererMixin",
     "compat.HighlightLineMixin"
   ],


### PR DESCRIPTION
Minecraft has some checks that decide if the outline should be rendered.
This results in the outline being invisible in some server lobbies, probable because you can't break blocks there.
So I added a config option to just ignore the checks and always render the outline.